### PR TITLE
Fix partial swiping on video shows black screen

### DIFF
--- a/ios/RCTVideoPlayerViewController.m
+++ b/ios/RCTVideoPlayerViewController.m
@@ -6,33 +6,11 @@
 
 @implementation RCTVideoPlayerViewController
 
-BOOL _viewWillAppearCalled = NO;
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    _viewWillAppearCalled = NO;
-}
-
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
-    if (_rctDelegate == nil || _viewWillAppearCalled)
-    {
-        [self dismissViewControllerAnimated:YES completion:nil];
-    }
-    _viewWillAppearCalled = YES;
-}
-
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewDidDisappear:animated];
-    [_rctDelegate videoPlayerViewControllerDidDismiss:self];
-}
-
-- (void)viewWillDisappear:(BOOL)animated {
-    [_rctDelegate videoPlayerViewControllerWillDismiss:self];
-    [super viewWillDisappear:animated];
+  [super viewDidDisappear:animated];
+  [_rctDelegate videoPlayerViewControllerWillDismiss:self];
+  [_rctDelegate videoPlayerViewControllerDidDismiss:self];
 }
 
 @end


### PR DESCRIPTION
In iOS 11, Apple added a feature to close the Video Player via a swipe gesture. Partial swiping cases viewWillDisappear to be called without viewDidDisappear which cases a black screen.